### PR TITLE
Changes to allow building images on RenkuLab

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,3 +9,7 @@ name: "base"
 channels:
   - conda-forge
 prefix: "/opt/conda"
+dependencies:
+  - pip
+  - pip:
+    - -r requirements.txt

--- a/post-init.sh
+++ b/post-init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 SCRIPT_DIR=$(dirname "$(realpath "$0")")
 
 pushd . > /dev/null

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,6 @@ pandas==2.*
 papermill==2.*
 plotly==6.*
 pyarrow==19.*
-pytorch-lightning==2.*
 scipy==1.*
-scikit-learn==1.*
 seaborn==0.13.*
-torch==2.*
 tqdm==4.*
-transformers==4.*

--- a/startup-buildback.sh
+++ b/startup-buildback.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+
+/cnb/lifecycle/launcher $SCRIPT_DIR/post-init.sh
+echo "" >> /home/renku/.bashrc
+/cnb/process/jupyterlab

--- a/startup.sh
+++ b/startup.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
+#!/bin/bash
 SCRIPT_DIR=$(dirname "$(realpath "$0")")
 
-sh $SCRIPT_DIR/post-init.sh
+bash $SCRIPT_DIR/post-init.sh
 jupyter server --ServerApp.ip=0.0.0.0 --ServerApp.port=8888 --ServerApp.base_url=$RENKU_BASE_URL_PATH --ServerApp.token="" --ServerApp.password="" --ServerApp.allow_remote_access=true --ContentsManager.allow_hidden=true --ServerApp.allow_origin=*


### PR DESCRIPTION
# Summary

This PR contains some minor changes to support building images on RenkuLab (instead of GitHub). This will make it possible to reduce session startup time by about 50% (in my testing, sessions started in around 1m 30s, compared to 3m 30s before the changes).