### PR TITLE
changes before prod

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,8 @@ name: Build image
 
 on:
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 env:

--- a/src/get_dataset_type.py
+++ b/src/get_dataset_type.py
@@ -1,11 +1,11 @@
 # %%
 import sys
-from opendata import OpenDataZH
+from opendata import OpenDataZurich
 
 
 def main(dataset_id):
     # Get the dataset
-    odz = OpenDataZH()
+    odz = OpenDataZurich()
     package = odz.get_package(dataset_id)
     if len(package.geo_resource_metadata_df) > 0:
         print("geo")

--- a/src/opendata.py
+++ b/src/opendata.py
@@ -143,7 +143,7 @@ def read_geojson_from_wfs(wfs, layer):
 
 
 # API
-class OpenDataZH:
+class OpenDataZurich:
     def __init__(self):
         self.provider = PROVIDER
         self.baselink_dataportal = BASELINK_DATAPORTAL

--- a/src/play.py
+++ b/src/play.py
@@ -3,10 +3,10 @@
 
 # %%
 import pandas as pd
-from opendata import OpenDataZH
+from opendata import OpenDataZurich
 from IPython.display import display, HTML, Markdown
 
-odz = OpenDataZH()
+odz = OpenDataZurich()
 
 # %%
 package = odz.get_package(name="bau_hae_lima_zuordnung_adr_quartier_bzo16_bzo99_od5143")

--- a/templates/TemplateCsv.ipynb
+++ b/templates/TemplateCsv.ipynb
@@ -9,9 +9,9 @@
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "from src.opendata import OpenDataZH\n",
+    "from src.opendata import OpenDataZurich\n",
     "\n",
-    "odz = OpenDataZH()"
+    "odz = OpenDataZurich()"
    ]
   },
   {
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Use the name of a dataset, e.g., from the OpenDataZH site or the list above, to get the package\n",
+    "# Use the name of a dataset, e.g., from the OpenDataZurich site or the list above, to get the package\n",
     "package = odz.get_package(name=package_id)"
    ]
   },

--- a/templates/TemplateGeo.ipynb
+++ b/templates/TemplateGeo.ipynb
@@ -9,9 +9,9 @@
     "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "from src.opendata import OpenDataZH\n",
+    "from src.opendata import OpenDataZurich\n",
     "\n",
-    "odz = OpenDataZH()"
+    "odz = OpenDataZurich()"
    ]
   },
   {
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Use the name of a dataset, e.g., from the OpenDataZH site or the list above, to get the package\n",
+    "# Use the name of a dataset, e.g., from the OpenDataZurich site or the list above, to get the package\n",
     "package = odz.get_package(name=package_id)"
    ]
   },
@@ -99,10 +99,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "streets_package = odz.get_package(name=\"ktzh_strassennetz__ogd_\")\n",
-    "city_resource = streets_package.geo_resource(0)\n",
-    "city_df = city_resource.layer_df(\"ogd-0278_arv_basis_up_gemeinden_stadtkreise_f\")\n",
-    "city_df = city_df[city_df[\"bezirksname\"] == \"Zürich\"]"
+    "# get background map with \"Stadtkreise\"\n",
+    "stadtkreise_package = odz.get_package(name=\"geo_stadtkreise\")\n",
+    "stadtkreise_resource = stadtkreise_package.geo_resource(0)\n",
+    "background_df = stadtkreise_resource.layer_df(\"adm_stadtkreise_a\")"
    ]
   },
   {
@@ -111,8 +111,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ax = city_df.plot(color=\"tab:gray\", alpha=0.2)\n",
-    "city_df.boundary.plot(ax=ax, color=\"tab:blue\", linewidth=0.5, alpha=0.7)\n",
+    "ax = background_df.plot(color=\"tab:gray\", alpha=0.2)\n",
+    "background_df.boundary.plot(ax=ax, color=\"tab:blue\", linewidth=0.5, alpha=0.7)\n",
     "df.plot(ax=ax, color=\"tab:red\", alpha=0.3, edgecolors='none')"
    ]
   },


### PR DESCRIPTION
Some cosmetic changes, before we go to prod on the data catalog like:

- build the container on when there are changes on main
- rename the internal metadata module to `OpenDataZurich` to prevent confusion with cantonal open data office
- use city internal geo data for background map