### PR TITLE
improve selection for geo datasets

### DIFF
--- a/src/opendata.py
+++ b/src/opendata.py
@@ -285,7 +285,7 @@ class OpenDataPackage:
     def geo_resource_metadata_df(self):
         if self._geo_resource_metadata_df is None:
             self._geo_resource_metadata_df = self.resource_metadata_df[
-                self.resource_metadata_df["format"].isin(["WFS", "JSON"])
+                self.resource_metadata_df['url'].str.contains('geojson')
             ]
         return self._geo_resource_metadata_df
 


### PR DESCRIPTION
Selection of the template (for tabular data or geo date) is not optimal. This is relevant on datasets that have json and csv resources, like `ugz_luftschadstoffmessung_tageswerte`.
Now the same logic is used to find geo datasets, like in 
https://github.com/opendatazurich/starter-code-generator/blob/main/updater.py#L151
