### PR TITLE
Remove uasage of filename field

### DIFF
--- a/src/opendata.py
+++ b/src/opendata.py
@@ -403,7 +403,6 @@ class OpenDataTabularResource:
         display(
             Markdown(
                 f"* **name** {self.metadata['name']}\n"
-                f"* **filename** {self.metadata['filename']}\n"
                 f"* **format** {self.metadata['format']}\n"
                 f"* **url** {self.metadata['url']}\n"
                 f"* **id** {self.metadata['id']}\n"

--- a/templates/TemplateCsv.ipynb
+++ b/templates/TemplateCsv.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "package.tabular_resource_metadata_df.head()[[\"filename\", \"format\"]]"
+    "package.tabular_resource_metadata_df.head()[[\"name\", \"format\"]]"
    ]
   },
   {


### PR DESCRIPTION
The field `filename` is not always present in the json from the api, as it is not mandatory. This causes errors in some cases.

But `name` serves the same purpose.

Replace `filename` with `name`